### PR TITLE
Follow crystal 1.0.0 in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: crystar
-version: 0.1.9
+version: 0.2.0
 description: |
   Shard Crystar implements access to tar archives. This shard aims to cover most variations of the format, including those produced by GNU and BSD tar tools.
 authors:

--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,6 @@ description: |
 authors:
   - Ali Naqvi <syed.alinaqvi@gmail.com>
 
-crystal: 0.36.0
+crystal: '>= 0.36.0, < 2.0.0'
 
 license: MIT

--- a/src/crystar.cr
+++ b/src/crystar.cr
@@ -35,7 +35,7 @@ require "./tar/*"
 # end
 # ```
 module Crystar
-  VERSION = "0.1.9"
+  VERSION = "0.2.0"
 
   # Common Crystar exceptions
   class Error < Exception


### PR DESCRIPTION
```console
$ crystal --version
Crystal 1.0.0 (2021-03-22)

LLVM: 9.0.1
Default target: x86_64-apple-macosx

$ crystal spec
..........................."Reading Crystar: spec/testdata/gnu.tar"
"Reading Crystar: spec/testdata/sparse-formats.tar"
"Reading Crystar: spec/testdata/star.tar"
"Reading Crystar: spec/testdata/v7.tar"
"Reading Crystar: spec/testdata/pax.tar"
"Reading Crystar: spec/testdata/pax-pos-size-file.tar"
"Reading Crystar: spec/testdata/pax-records.tar"
"Reading Crystar: spec/testdata/trailing-slash.tar"
"Reading Crystar: spec/testdata/pax-nil-sparse-data.tar"
"Reading Crystar: spec/testdata/gnu-utf8.tar"
"Reading Crystar: spec/testdata/gnu-not-utf8.tar"
"Reading Crystar: spec/testdata/gnu-incremental.tar"
"Reading Crystar: spec/testdata/pax-multi-hdrs.tar"
"Reading Crystar: spec/testdata/gnu-long-nul.tar"
."Reading Crystar: spec/testdata/pax-bad-hdr-file.tar"
"Reading Crystar: spec/testdata/pax-bad-mtime-file.tar"
"Reading Crystar: spec/testdata/pax-nul-xattrs.tar"
"Reading Crystar: spec/testdata/pax-nul-path.tar"
"Reading Crystar: spec/testdata/neg-size.tar"
.

Finished in 13.68 milliseconds
29 examples, 0 failures, 0 errors, 0 pending
```

So I think this shard will work in crystal 1.0.0 ☺️ 

But user using crystal 1.0.0 and shards 0.14.1 raises an error when `--ignore-crystal-version` not given.

So this change might reduce the annoying error for shards users? 🤔

https://github.com/crystal-lang/shards/blob/addc26a3f22fee9fccb01cbb3e8878bef02d4295/docs/shard.yml.adoc

>When just a version number is used it has a different semantic compared to dependencies: x.y.z will be interpreted as ~> x.y, >= x.y.z (ie: >= x.y.z, < (x+1).0.0) honoring semver.