### PR TITLE
Fixing Crystal 1.6 compilation error

### DIFF
--- a/src/tar/header.cr
+++ b/src/tar/header.cr
@@ -419,8 +419,7 @@ module Crystar
     end
   end
 
-  # HeaderFileInfo extends File::Info
-  private struct HeaderFileInfo < File::Info
+  private struct HeaderFileInfo
     getter header : Header
 
     def initialize(@header)


### PR DESCRIPTION
Fixes #11

It looks like this struct didn't need to inherit from `File::Info` here. The specs now run and pass on Crystal 1.6.

Ref: https://github.com/crystal-lang/crystal/issues/12470